### PR TITLE
Pricing change and extracted oracle logic

### DIFF
--- a/contracts/ChainlinkPriceOracle.sol
+++ b/contracts/ChainlinkPriceOracle.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {IPolicyPool} from "@ensuro/core/contracts/interfaces/IPolicyPool.sol";
+import {IPremiumsAccount} from "@ensuro/core/contracts/interfaces/IPremiumsAccount.sol";
+import {RiskModule} from "@ensuro/core/contracts/RiskModule.sol";
+import {Policy} from "@ensuro/core/contracts/Policy.sol";
+import {WadRayMath} from "./dependencies/WadRayMath.sol";
+import {IPriceOracle} from "./interfaces/IPriceOracle.sol";
+
+/**
+ * @title PriceRiskModule
+ * @dev Risk Module that triggers the payout if the price of an asset is lower or higher than trigger price
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+contract ChainlinkPriceOracle is IPriceOracle {
+  using WadRayMath for uint256;
+
+  uint8 internal constant WAD_DECIMALS = 18;
+
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+  AggregatorV3Interface internal immutable _assetOracle;
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+  AggregatorV3Interface internal immutable _referenceOracle;
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+  uint256 internal _oracleTolerance;
+
+  /**
+   * @dev Constructs the PriceRiskModule.
+   *      Note that, although it's supported that assetOracle_ and  referenceOracle_ have different number
+   *      of decimals, they're assumed to be in the same denomination. For instance, assetOracle_ could be
+   *      WMATIC/ETH and referenceOracle_ could be for USDC/ETH.
+   *      This cannot be validated by the contract, so be careful when constructing.
+   *
+   * @param assetOracle_ Address of the price feed oracle for the asset
+   * @param referenceOracle_ Address of the price feed oracle for the reference currency. If it's
+   *                         the zero address the asset price will be considered directly.
+   * @param oracleTolerance_ Max acceptable age of price data, in seconds
+   */
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor(
+    AggregatorV3Interface assetOracle_,
+    AggregatorV3Interface referenceOracle_,
+    uint256 oracleTolerance_
+  ) {
+    require(
+      address(assetOracle_) != address(0),
+      "PriceRiskModule: assetOracle_ cannot be the zero address"
+    );
+    _assetOracle = assetOracle_;
+    _referenceOracle = referenceOracle_;
+    _oracleTolerance = oracleTolerance_;
+  }
+
+  /**
+   * @dev Returns the price of the asset
+   *
+   * Requirements:
+   * - The oracle(s) are functional, returning non zero values and updated after (block.timestamp - oracleTolerance())
+   *
+   * @return If referenceOracle() != address(0), returns the price of the asset expressed in terms of the reference
+   *         asset, in Wad (18 decimals)
+   *         If referenceOracle() == address(0), returns the price of the asset expressed in the denomination of
+   *         assetOracle(), in Wad (18 decimals)
+   */
+  function getCurrentPrice() public view override returns (uint256) {
+    if (address(_referenceOracle) == address(0)) {
+      return _scalePrice(_getLatestPrice(_assetOracle), _assetOracle.decimals(), WAD_DECIMALS);
+    } else {
+      return _convert(_assetOracle, _referenceOracle, 10**_assetOracle.decimals());
+    }
+  }
+
+  /**
+   * @dev Converts between two assets given their price aggregators
+   * @param from the aggregator for the origin asset
+   * @param to the aggregator for the destination asset
+   * @param amount the amount to convert, expressed with the same decimals as the from aggregator
+   * @return The converted amount, expressed with the same decimals as the to aggregator
+   */
+  function _convert(
+    AggregatorV3Interface from,
+    AggregatorV3Interface to,
+    uint256 amount
+  ) internal view returns (uint256) {
+    require(
+      address(from) != address(0) && address(to) != address(0),
+      "Both oracles required for conversion"
+    );
+    return _scalePrice(amount, from.decimals(), WAD_DECIMALS).wadMul(_getExchangeRate(from, to));
+  }
+
+  /**
+   * @dev Calculates the exchange rate between the prices returned by the two aggregators
+   *      Assumes that both aggregators are returning prices using the same quote.
+   *      Although it's usual that the aggregators return prices with the same number of
+   *      decimals, this is not required. Both prices will be scaled to Wad before calculating the
+   *      rate.
+   * @param base the aggregator for the base
+   * @param quote the aggregator for the quote asset. Can be the zero address, in which case the
+   *              base asset price is returned without any calculations performed.
+   * @return The exchange rate from/to in Wad
+   */
+  function _getExchangeRate(AggregatorV3Interface base, AggregatorV3Interface quote)
+    internal
+    view
+    returns (uint256)
+  {
+    require(address(base) != address(0), "Base oracle required");
+
+    uint256 basePrice = _scalePrice(_getLatestPrice(base), base.decimals(), WAD_DECIMALS);
+    require(basePrice != 0, "Price from not available");
+
+    if (address(quote) == address(0)) return basePrice;
+
+    uint256 quotePrice = _scalePrice(_getLatestPrice(quote), quote.decimals(), WAD_DECIMALS);
+    require(quotePrice != 0, "Price to not available");
+
+    return basePrice.wadDiv(quotePrice);
+  }
+
+  function _getLatestPrice(AggregatorV3Interface oracle) internal view returns (uint256) {
+    (, int256 price, , uint256 updatedAt, ) = oracle.latestRoundData();
+    require(updatedAt > block.timestamp - _oracleTolerance, "Price is older than tolerable");
+
+    return SafeCast.toUint256(price);
+  }
+
+  function _scalePrice(
+    uint256 price,
+    uint8 priceDecimals,
+    uint8 decimals
+  ) internal pure returns (uint256) {
+    if (priceDecimals < decimals) return price * 10**(decimals - priceDecimals);
+    else return price / 10**(priceDecimals - decimals);
+  }
+
+  function referenceOracle() external view returns (AggregatorV3Interface) {
+    return _referenceOracle;
+  }
+
+  function assetOracle() external view returns (AggregatorV3Interface) {
+    return _assetOracle;
+  }
+
+  function oracleTolerance() external view returns (uint256) {
+    return _oracleTolerance;
+  }
+}

--- a/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/interfaces/IPriceOracle.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import {IRiskModule} from "@ensuro/core/contracts/interfaces/IRiskModule.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+/**
+ * @title IPriceOracle interface
+ * @dev Interface for price oracles that returns the price (in Wad) for a given asset.
+ *      It encapsulates the complexities of the underlying oracle, the validations and the reference currency used
+ *      to express the price. That reference currency is implicit.
+ * @author Ensuro
+ */
+interface IPriceOracle {
+  /**
+   * @dev Returns the price of the asset (the reference whether it's another crypto asset or USD is implicit)
+   *
+   * Requirements:
+   * - The underlying oracle(s) are functional. It NEVER returns zero.
+   *
+   * @return The price of the asset in Wad (18 decimals)
+   */
+  function getCurrentPrice() external view returns (uint256);
+}

--- a/contracts/interfaces/IPriceRiskModule.sol
+++ b/contracts/interfaces/IPriceRiskModule.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import {IRiskModule} from "@ensuro/core/contracts/interfaces/IRiskModule.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IPriceOracle} from "./IPriceOracle.sol";
 
 /**
  * @title IPriceRiskModule interface
@@ -12,20 +13,31 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
  */
 interface IPriceRiskModule is IRiskModule {
   /**
+   * @dev Struct that represents the pricing parameters for a given slot.
+   *      Includes the lossProb (used to compute the pure premium) and the collateralization ratios
+   */
+  struct SlotPricing {
+    uint64 lossProb;
+    uint64 jrCollRatio;
+    uint64 collRatio;
+  }
+
+  /**
    * @dev Returns the premium and lossProb of the policy
    * @param triggerPrice Price of the asset_ that will trigger the policy (expressed in _currency)
    * @param lower If true -> triggers if the price is lower, If false -> triggers if the price is higher
    * @param payout Expressed in policyPool.currency()
    * @param expiration Expiration of the policy
    * @return premium Premium that needs to be paid
-   * @return lossProb Probability of paying the maximum payout
+   * @return price SlotPricing struct with the loss probability of paying the maximum payout and collateralization
+   *               levels
    */
   function pricePolicy(
     uint256 triggerPrice,
     bool lower,
     uint256 payout,
     uint40 expiration
-  ) external view returns (uint256 premium, uint256 lossProb);
+  ) external view returns (uint256 premium, SlotPricing memory price);
 
   function newPolicy(
     uint256 triggerPrice,
@@ -37,15 +49,7 @@ interface IPriceRiskModule is IRiskModule {
 
   function triggerPolicy(uint256 policyId) external;
 
-  function referenceOracle() external view returns (AggregatorV3Interface);
-
-  function assetOracle() external view returns (AggregatorV3Interface);
-
-  /**
-   * @dev  Max acceptable age for price data.
-   *       If the most recent price is older than (now - tolerance) no policies can be created or resolved.
-   */
-  function oracleTolerance() external view returns (uint40);
+  function oracle() external view returns (IPriceOracle);
 
   /**
    * @dev In seconds, the minimum time that must elapse before a policy can be triggered, since creation

--- a/contracts/mocks/PriceOracleMock.sol
+++ b/contracts/mocks/PriceOracleMock.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {IPriceOracle} from "../interfaces/IPriceOracle.sol";
+
+contract PriceOracleMock is IPriceOracle {
+  uint256 internal _price;
+
+  constructor(uint256 price) {
+    _price = price;
+  }
+
+  function getCurrentPrice() external view override returns (uint256) {
+    // require(_price != 0, "Error, price can't be zero");
+    return _price;
+  }
+
+  function setPrice(uint256 price_) external {
+    _price = price_;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@chainlink/contracts": "^0.5.1",
-        "@ensuro/core": "^2.0.0",
+        "@ensuro/core": "^2.2.0-beta1",
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3"
       },
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@ensuro/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ensuro/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-FIywyvcSX8pIoPLj73JMIgFsv6ym8dHl54ZnvIMbuzJY2Bazbjaj+B50n1dwhvpP4KH/jw+j8yuqUjIJ/xcZPA=="
+      "version": "2.2.0-beta1",
+      "resolved": "https://registry.npmjs.org/@ensuro/core/-/core-2.2.0-beta1.tgz",
+      "integrity": "sha512-lrDkL6agEjG1/bhAyWd8z3kWXB5X3NlgVcMtuvHPTBqGs+1MMDm9Bb5py1AP16zXernzGQ7wK+/s8N/faAw2wA=="
     },
     "node_modules/@eth-optimism/contracts": {
       "version": "0.5.37",
@@ -10269,9 +10269,9 @@
       }
     },
     "@ensuro/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ensuro/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-FIywyvcSX8pIoPLj73JMIgFsv6ym8dHl54ZnvIMbuzJY2Bazbjaj+B50n1dwhvpP4KH/jw+j8yuqUjIJ/xcZPA=="
+      "version": "2.2.0-beta1",
+      "resolved": "https://registry.npmjs.org/@ensuro/core/-/core-2.2.0-beta1.tgz",
+      "integrity": "sha512-lrDkL6agEjG1/bhAyWd8z3kWXB5X3NlgVcMtuvHPTBqGs+1MMDm9Bb5py1AP16zXernzGQ7wK+/s8N/faAw2wA=="
     },
     "@eth-optimism/contracts": {
       "version": "0.5.37",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^0.5.1",
-    "@ensuro/core": "^2.0.0",
+    "@ensuro/core": "^2.2.0-beta1",
     "@openzeppelin/contracts": "^4.7.3",
     "@openzeppelin/contracts-upgradeable": "^4.7.3"
   },

--- a/test/test-chainlink-price-oracle.js
+++ b/test/test-chainlink-price-oracle.js
@@ -1,0 +1,177 @@
+const { expect } = require("chai");
+const hre = require("hardhat");
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
+const {
+  amountFunction,
+  initCurrency,
+  deployPool,
+  deployPremiumsAccount,
+  _E,
+  _W,
+  addRiskModule,
+  grantComponentRole,
+  addEToken,
+  getTransactionEvent,
+  accessControlMessage,
+  _R,
+  grantRole,
+  blockchainNow,
+} = require("@ensuro/core/js/test-utils");
+
+const HOUR = 3600;
+
+hre.upgrades.silenceWarnings();
+
+const skipForkTests = process.env.SKIP_FORK_TESTS === "true";
+const forkIt = skipForkTests ? it.skip : it;
+
+describe("Test PriceRiskModule contract", function () {
+  let owner, lp, cust;
+  const _A = amountFunction(6);
+  const _A8 = amountFunction(8);
+  const _A20 = amountFunction(20);
+  let ChainlinkPriceOracle;
+
+  beforeEach(async () => {
+    [owner, lp, cust] = await hre.ethers.getSigners();
+    ChainlinkPriceOracle = await hre.ethers.getContractFactory("ChainlinkPriceOracle");
+  });
+
+  async function addRound(oracle, price, startedAt, updatedAt, answeredInRound) {
+    const now = await helpers.time.latest();
+    return oracle._addRound(price, startedAt || now, updatedAt || now, answeredInRound || 0);
+  }
+
+  async function deployAggMock(decimals = 8) {
+    const AggregatorV3Mock = await hre.ethers.getContractFactory("AggregatorV3Mock");
+    const aggContract = AggregatorV3Mock.deploy(decimals);
+    return aggContract;
+  }
+
+  it("Should construct the ChainlinkPriceOracle", async () => {
+    const reference = await deployAggMock(8);
+    const asset = await deployAggMock(8);
+    const oracle = await ChainlinkPriceOracle.deploy(asset.address, reference.address, 3600);
+    expect(await oracle.assetOracle()).to.be.equal(asset.address);
+    expect(await oracle.referenceOracle()).to.be.equal(reference.address);
+    expect(await oracle.oracleTolerance()).to.be.equal(3600);
+  });
+
+  it("Should revert if assetOracle=0 but accept referenceOracle=0", async () => {
+    const asset = await deployAggMock(8);
+    await expect(
+      ChainlinkPriceOracle.deploy(ethers.constants.AddressZero, ethers.constants.AddressZero, 3600)
+    ).to.be.revertedWith("PriceRiskModule: assetOracle_ cannot be the zero address");
+
+    const oracle = await ChainlinkPriceOracle.deploy(asset.address, ethers.constants.AddressZero, 3600);
+    expect(await oracle.assetOracle()).to.be.equal(asset.address);
+    expect(await oracle.referenceOracle()).to.be.equal(ethers.constants.AddressZero);
+    expect(await oracle.oracleTolerance()).to.be.equal(3600);
+  });
+
+  it("getCurrentPrice should revert if prices are zero or old", async () => {
+    const now = await helpers.time.latest();
+    const reference = await deployAggMock(8);
+    const asset = await deployAggMock(8);
+    const oracle = await ChainlinkPriceOracle.deploy(asset.address, reference.address, 3600);
+
+    await expect(oracle.getCurrentPrice()).to.be.revertedWith("Price is older than tolerable");
+
+    await addRound(asset, 0);
+    await expect(oracle.getCurrentPrice()).to.be.revertedWith("Price from not available");
+    await addRound(asset, _A8("1.5"), now - 3800, now - 3800);
+    await expect(oracle.getCurrentPrice()).to.be.revertedWith("Price is older than tolerable");
+    await addRound(asset, _A8("2.5"), now, now);
+
+    // Keeps failing because of referenceOracle missing price
+    await expect(oracle.getCurrentPrice()).to.be.revertedWith("Price is older than tolerable");
+    await addRound(reference, 0);
+    await expect(oracle.getCurrentPrice()).to.be.revertedWith("Price to not available");
+    await addRound(reference, _A8("0.1"), now - 3800, now - 3800);
+    await expect(oracle.getCurrentPrice()).to.be.revertedWith("Price is older than tolerable");
+    await addRound(reference, _A8("0.5"), now, now);
+
+    expect(await oracle.getCurrentPrice()).to.be.equal(_W("5"));
+  });
+
+  it("If not reference, returns just the asset price", async () => {
+    const asset = await deployAggMock(8);
+    const oracle = await ChainlinkPriceOracle.deploy(asset.address, ethers.constants.AddressZero, 3600);
+
+    await addRound(asset, _A8("34.2"));
+    expect(await oracle.getCurrentPrice()).to.be.equal(_W("34.2"));
+  });
+
+  it("It works fine with different decimal combinations", async () => {
+    // Asset = 6 decimals / Reference = 8 decimals
+    let asset = await deployAggMock(6);
+    let reference = await deployAggMock(8);
+    let oracle = await ChainlinkPriceOracle.deploy(asset.address, reference.address, 3600);
+
+    await addRound(asset, _A("10"));
+    await addRound(reference, _A8("2"));
+    expect(await oracle.getCurrentPrice()).to.be.equal(_W("5"));
+    await addRound(reference, _A8("20"));
+    expect(await oracle.getCurrentPrice()).to.be.equal(_W(".5"));
+
+    // Asset = 8 decimals / Reference = 6 decimals
+    asset = await deployAggMock(8);
+    reference = await deployAggMock(6);
+    oracle = await ChainlinkPriceOracle.deploy(asset.address, reference.address, 3600);
+    await addRound(asset, _A8("10"));
+    await addRound(reference, _A("2"));
+    expect(await oracle.getCurrentPrice()).to.be.equal(_W("5"));
+
+    // Asset = 18 decimals / Reference = 20 decimals
+    asset = await deployAggMock(18);
+    reference = await deployAggMock(20);
+    oracle = await ChainlinkPriceOracle.deploy(asset.address, reference.address, 3600);
+    await addRound(asset, _W("8"));
+    await addRound(reference, _A20("2"));
+    expect(await oracle.getCurrentPrice()).to.be.equal(_W("4"));
+
+    // Asset = 20 decimals / Reference = null
+    asset = await deployAggMock(20);
+    reference = await deployAggMock(20);
+    oracle = await ChainlinkPriceOracle.deploy(asset.address, ethers.constants.AddressZero, 3600);
+    await addRound(asset, _A20("8"));
+    expect(await oracle.getCurrentPrice()).to.be.equal(_W("8"));
+  });
+
+  forkIt("Should work with real chainlink oracles (forking at https://polygonscan.com/block/34906609)", async () => {
+    if (process.env.ALCHEMY_URL === undefined) throw new Error("Define envvar ALCHEMY_URL for this test");
+    await hre.network.provider.request({
+      method: "hardhat_reset",
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: process.env.ALCHEMY_URL,
+            blockNumber: 34906609, // polygon mainnet
+          },
+        },
+      ],
+    });
+
+    const _U = amountFunction(8);
+
+    const BNB_ORACLE_ADDRESS = "0x82a6c4AF830caa6c97bb504425f6A66165C2c26e";
+    const USDC_ORACLE_ADDRESS = "0xfE4A8cc5b5B2366C1B58Bea3858e81843581b2F7";
+
+    const assetOracle = await hre.ethers.getContractAt("AggregatorV3Interface", BNB_ORACLE_ADDRESS);
+    const referenceOracle = await hre.ethers.getContractAt("AggregatorV3Interface", USDC_ORACLE_ADDRESS);
+
+    // Sanity check: are we in the right chain with the right block?
+    const [, assetPrice] = await assetOracle.latestRoundData();
+    expect(assetPrice).to.equal(_U("293.18"));
+    const [, referencePrice] = await referenceOracle.latestRoundData();
+    expect(referencePrice).to.equal(_U("1.00002339"));
+
+    // Contract setup
+    const oracle = await ChainlinkPriceOracle.deploy(assetOracle.address, referenceOracle.address, HOUR);
+    expect(await oracle.getCurrentPrice()).to.closeTo(_E("293.17314268"), _E("0.00000001"));
+
+    const inverseOracle = await ChainlinkPriceOracle.deploy(referenceOracle.address, assetOracle.address, HOUR);
+
+    expect(await inverseOracle.getCurrentPrice()).to.closeTo(_E("0.00341095"), _E("0.00000001"));
+  });
+});

--- a/test/test-price-risk-module.js
+++ b/test/test-price-risk-module.js
@@ -39,31 +39,33 @@ describe("Test PriceRiskModule contract", function () {
   it("Should return the asset oracle", async () => {
     const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, assetOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    expect(await rm.assetOracle()).to.equal(assetOracle.address);
+    expect(await rm.oracle()).to.equal(oracle.address);
   });
 
-  it("Should return the reference oracle", async () => {
+  it("Should return the minDuration", async () => {
     const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    expect(await rm.referenceOracle()).to.equal(referenceOracle.address);
+    expect(await rm.minDuration()).to.equal(HOUR);
   });
 
-  it("Should return the oracle tolerance", async () => {
+  it("Should revert if oracle = address(0)", async () => {
     const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const oracle = { address: ethers.constants.AddressZero };
 
-    expect(await rm.oracleTolerance()).to.equal(HOUR);
+    await expect(addPriceRiskModule(pool, premiumsAccount, oracle)).to.be.revertedWith(
+      "PriceRiskModule: oracle_ cannot be the zero address"
+    );
   });
 
   it("Should never allow reinitialization", async () => {
     const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
     await expect(
       rm.initialize(
@@ -74,34 +76,40 @@ describe("Test PriceRiskModule contract", function () {
         _A("1000"),
         _A("10000"),
         "0x87c47c9a5a2aa74ae714857d64911d9a091c25b1",
-        HOUR
+        oracle.address
       )
     ).to.be.revertedWith("Initializable: contract is already initialized");
   });
 
-  it("Should only allow ORACLE_ADMIN to set the oracleTolerance", async () => {
+  it("Should only allow ORACLE_ADMIN to change the oracle", async () => {
     const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    expect(await rm.oracleTolerance()).to.equal(HOUR);
+    expect(await rm.oracle()).to.equal(oracle.address);
 
-    await expect(rm.setOracleTolerance(HOUR / 2)).to.be.revertedWith(
+    const PriceOracleMock = await hre.ethers.getContractFactory("PriceOracleMock");
+    const newOracle = await PriceOracleMock.deploy(_W(2));
+
+    await expect(rm.setOracle(newOracle.address)).to.be.revertedWith(
       accessControlMessage(owner.address, rm.address, "ORACLE_ADMIN_ROLE")
     );
-    expect(await rm.oracleTolerance()).to.equal(HOUR);
 
     await grantComponentRole(hre, accessManager, rm, "ORACLE_ADMIN_ROLE", owner.address);
 
-    await expect(rm.setOracleTolerance(HOUR / 2)).not.to.be.reverted;
+    await expect(rm.setOracle(ethers.constants.AddressZero)).to.be.revertedWith(
+      "PriceRiskModule: oracle_ cannot be the zero address"
+    );
 
-    expect(await rm.oracleTolerance()).to.equal(HOUR / 2);
+    await expect(rm.setOracle(newOracle.address)).not.to.be.reverted;
+
+    expect(await rm.oracle()).to.equal(newOracle.address);
   });
 
   it("Should only allow ORACLE_ADMIN to set the minDuration", async () => {
     const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
     expect(await rm.minDuration()).to.equal(HOUR);
 
@@ -120,14 +128,14 @@ describe("Test PriceRiskModule contract", function () {
   it("Should only allow PRICER to set CDFs", async () => {
     const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    const newCdf = _makeArray(await rm.PRICE_SLOTS(), 0);
-    newCdf[0] = _W("0.2");
-    newCdf[newCdf.length - 1] = _W("0.5");
+    const newCdf = Array(await rm.PRICE_SLOTS()).fill([0, 0, 0]);
+    newCdf[0] = [_W("0.2"), _W("0.3"), _W("0.9")];
+    newCdf[newCdf.length - 1] = [_W("0.5"), _W(0), _W(0)];
 
-    expect((await rm.getCDF(1))[0]).to.equal(_W(0));
-    expect((await rm.getCDF(1))[newCdf.length - 1]).to.equal(_W(0));
+    expect((await rm.getCDF(1))[0][0]).to.equal(_W(0));
+    expect((await rm.getCDF(1))[newCdf.length - 1][0]).to.equal(_W(0));
 
     await expect(rm.setCDF(1, newCdf)).to.be.revertedWith(
       accessControlMessage(owner.address, rm.address, "PRICER_ROLE")
@@ -136,18 +144,33 @@ describe("Test PriceRiskModule contract", function () {
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
     await expect(rm.connect(owner).setCDF(1, newCdf)).not.to.be.reverted;
 
-    expect((await rm.getCDF(1))[0]).to.equal(_W("0.2"));
-    expect((await rm.getCDF(1))[newCdf.length - 1]).to.equal(_W("0.5"));
+    const actualCDF = await rm.getCDF(1);
+
+    expect(actualCDF[0].lossProb).to.equal(_W("0.2"));
+    expect(actualCDF[0].jrCollRatio).to.equal(_W("0.3"));
+    expect(actualCDF[0].collRatio).to.equal(_W("0.9"));
+    expect(actualCDF[newCdf.length - 1].lossProb).to.equal(_W("0.5"));
+    expect(actualCDF[newCdf.length - 1].jrCollRatio).to.equal(_W("0"));
+    expect(actualCDF[newCdf.length - 1].collRatio).to.equal(_W("0"));
+
+    newCdf[newCdf.length - 2] = [_W("0.2"), _W("1.2"), _W(0)];
+    await expect(rm.setCDF(1, newCdf)).to.be.revertedWith("Validation: invalid collateralization ratios");
+
+    newCdf[newCdf.length - 2] = [_W("0.2"), _W("0.3"), _W("1.3")];
+    await expect(rm.setCDF(1, newCdf)).to.be.revertedWith("Validation: invalid collateralization ratios");
+
+    newCdf[newCdf.length - 2] = [_W("0.2"), _W("0.4"), _W("0.3")];
+    await expect(rm.setCDF(1, newCdf)).to.be.revertedWith("Validation: invalid collateralization ratios");
   });
 
   it("Should not allow setting prices for policies with no duration", async () => {
     const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    const newCdf = _makeArray(await rm.PRICE_SLOTS(), 0);
-    newCdf[0] = _W("0.2");
-    newCdf[newCdf.length - 1] = _W("0.5");
+    const newCdf = Array(await rm.PRICE_SLOTS()).fill([0, 0, 0]);
+    newCdf[0] = [_W("0.2"), _W("0.3"), _W("0.9")];
+    newCdf[newCdf.length - 1] = [_W("0.5"), _W(0), _W(0)];
 
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
 
@@ -157,196 +180,100 @@ describe("Test PriceRiskModule contract", function () {
   it("Should not allow new policies if prices are not defined", async () => {
     const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    // Last round for the asset has no price
-    await addRound(assetOracle, _E("0"));
-    await expect(rm.pricePolicy(_E("100"), true, _A(1000), HOUR)).to.be.revertedWith("Price from not available");
-
-    // Last round for the asset has a price but the reference doesn't
-    await addRound(assetOracle, _E("1"));
-    await addRound(referenceOracle, _E("0"));
-    await expect(rm.pricePolicy(_E("100"), true, _A(1000), HOUR)).to.be.revertedWith("Price to not available");
-  });
-
-  it("Should not allow new policies if prices are not fresh", async () => {
-    const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
-
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
-
-    const now = await blockchainNow(owner);
-
-    // The price for the asset is twice as old as tolerance
-    const tolerance = await rm.oracleTolerance();
-    await addRound(assetOracle, _E("100"), now - tolerance * 2, now - tolerance * 2);
-
-    // The price for the reference is current
-    await addRound(referenceOracle, _E("130"));
-
-    await expect(rm.pricePolicy(_E("2"), true, _A(1000), HOUR)).to.be.revertedWith("Price is older than tolerable");
-
-    // The asset price is now current
-    await addRound(assetOracle, _E("100"));
-
-    // The reference price is old
-    await addRound(referenceOracle, _E("130"), now - tolerance, now - tolerance);
-
-    await expect(rm.pricePolicy(_E("2"), true, _A(1000), HOUR)).to.be.revertedWith("Price is older than tolerable");
-  });
-
-  it("Should not allow address(0) for the asset oracle", async () => {
-    const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
-
-    const PriceRiskModule = await hre.ethers.getContractFactory("PriceRiskModule");
-    await expect(
-      addRiskModule(pool, premiumsAccount, PriceRiskModule, {
-        extraConstructorArgs: [hre.ethers.constants.AddressZero, hre.ethers.constants.AddressZero, _W("0.01")],
-        extraArgs: [HOUR],
-      })
-    ).to.be.revertedWith("PriceRiskModule: assetOracle_ cannot be the zero address");
+    // We don't have explicit validation againts current price = 0 because IPriceOracle must return
+    // something != 0 or revert. Anyway, our code reverts anyway if a faulty IPriceOracle returns
+    // getCurrentPrice() = 0.
+    await expect(rm.pricePolicy(_E("100"), false, _A(1000), HOUR)).to.be.reverted;
+    await expect(rm.pricePolicy(_E("100"), true, _A(1000), HOUR)).to.be.revertedWith("Price already at trigger value");
   });
 
   it("Should not allow address(0) for the policy owner", async () => {
     const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
     await expect(
       rm
         .connect(cust)
-        .newPolicy(_E("1.1"), true, _A(1000), await blockchainNow(owner), hre.ethers.constants.AddressZero)
+        .newPolicy(_E("1.1"), true, _A(1000), await helpers.time.latest(), hre.ethers.constants.AddressZero)
     ).to.be.revertedWith("onBehalfOf cannot be the zero address");
   });
 
   it("Should reject if trigger price has already been reached", async () => {
     const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    await addRound(assetOracle, _E("0.0005")); // 1 ETH = 2000 WMATIC
-    await addRound(referenceOracle, _E("0.000333333")); // 1 ETH = 3000 USDC
-    // Therefore 1 WMATIC = 1.5 USDC
+    await oracle.setPrice(_E("1.5"));
 
     await expect(rm.pricePolicy(_E("2"), true, _A(1000), HOUR)).to.be.revertedWith("Price already at trigger value");
 
     await expect(rm.pricePolicy(_E("1"), false, _A(1000), HOUR)).to.be.revertedWith("Price already at trigger value");
   });
 
-  it("Should allow address(0) for the reference oracle", async () => {
-    const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
-
-    const PriceRiskModule = await hre.ethers.getContractFactory("PriceRiskModule");
-
-    const rm = await addRiskModule(pool, premiumsAccount, PriceRiskModule, {
-      extraConstructorArgs: [
-        "0x82a6c4AF830caa6c97bb504425f6A66165C2c26e",
-        hre.ethers.constants.AddressZero,
-        _W("0.01"),
-      ],
-      extraArgs: [HOUR],
-    });
-
-    expect(await rm.referenceOracle()).to.equal(hre.ethers.constants.AddressZero);
-  });
-
-  it("Should calculate exchange rate for single asset with no reference", async () => {
-    const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
-
-    const { rm, assetOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, undefined);
-
-    expect(await rm.referenceOracle()).to.equal(hre.ethers.constants.AddressZero);
-
-    await addRound(assetOracle, _E("0.0005")); // 1 ETH = 2000 USD
-
-    expect(await rm.getCurrentPrice()).to.equal(_E("0.0005"));
-  });
-
   it("Should calculate policy premium and loss for single asset with no reference", async () => {
     const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, assetOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18);
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    await addRound(assetOracle, _E("0.00125")); // 1 ETH = 800 USDC
+    await oracle.setPrice(_E("0.00125")); // 1 ETH = 800 USDC
 
-    const start = await blockchainNow(owner);
+    const start = await helpers.time.latest();
 
-    const [price0, lossProb0] = await rm.pricePolicy(_E("0.001"), true, _A(1000), start + HOUR * 2);
-    expect(price0).to.equal(0);
-    expect(lossProb0).to.equal(0);
+    const [premium0, price0] = await rm.pricePolicy(_E("0.001"), true, _A(1000), start + HOUR * 2);
+    expect(premium0).to.equal(0);
+    expect(price0.lossProb).to.equal(0);
 
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
 
     const priceSlots = await rm.PRICE_SLOTS();
 
     const cdf = new Array(priceSlots);
-    for (let i = 0; i < priceSlots; i++) cdf[i] = _W(i / 100);
-    cdf[priceSlots - 1] = _W("0.5");
+    for (let i = 0; i < priceSlots; i++) {
+      cdf[i] = [_W(i / 100), 0, _W(1)];
+    }
+    cdf[26] = [_W("0.04"), _W("0.3"), _W("0.5")];
+    cdf[priceSlots - 1] = [_W("0.5"), _W(0), _W(1)];
     await rm.connect(owner).setCDF(2, cdf);
 
     // With a variation of 0.4% we have the probability of the first slot
-    let [premium, lossProb] = await rm.pricePolicy(_E("0.00124502"), true, _A(1000), start + HOUR * 2);
-    expect(lossProb).to.equal(_W(0));
+    let [premium, pricing] = await rm.pricePolicy(_E("0.00124502"), true, _A(1000), start + HOUR * 2);
+    expect(pricing.lossProb).to.equal(_W(0));
     expect(premium).to.equal(_W(0));
 
     // With a variation of 12.3% we have the probability of the 12th slot
-    [premium, lossProb] = await rm.pricePolicy(_E("0.00109625"), true, _A(1000), start + HOUR * 2);
-    expect(lossProb).to.equal(_W("0.12"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, start + HOUR * 2));
+    [premium, pricing] = await rm.pricePolicy(_E("0.00109625"), true, _A(1000), start + HOUR * 2);
+    expect(pricing.lossProb).to.equal(_W("0.12"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), pricing.lossProb, start + HOUR * 2));
 
     // With a variation of 26.6% we have the probability of the 27th slot
-    [premium, lossProb] = await rm.pricePolicy(_E("0.0009175"), true, _A(1000), start + HOUR * 2);
-    expect(lossProb).to.equal(_W("0.27"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, start + HOUR * 2));
+    [premium, pricing] = await rm.pricePolicy(_E("0.0009175"), true, _A(1000), start + HOUR * 2);
+    expect(pricing.lossProb).to.equal(_W("0.27"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), pricing.lossProb, start + HOUR * 2));
+
+    // With a variation of 25.8% we have the probability of the 26th slot
+    [premium, pricing] = await rm.pricePolicy(_E("0.0009275"), true, _A(1000), start + HOUR * 2);
+    expect(pricing.lossProb).to.equal(_W("0.04"));
+    expect(premium).to.equal(await rm.getMinimumPremiumForPricing(_A(1000), cdf[26], start + HOUR * 2));
 
     // With a variation of 46.6% we have the probability of the last slot
-    [premium, lossProb] = await rm.pricePolicy(_E("0.0006675"), true, _A(1000), start + HOUR * 2);
-    expect(lossProb).to.equal(_W("0.5"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, start + HOUR * 2));
-  });
-
-  it("Should calculate exchange rate between different assets (Wad vs 6 decimals)", async () => {
-    const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
-
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 6);
-
-    await addRound(assetOracle, _E("0.2"));
-    await addRound(referenceOracle, _A(0.5));
-
-    expect(await rm.getCurrentPrice()).to.equal(_A("0.4")); // price expressed in the reference asset
-
-    const inverseRm = await addPriceRiskModule(pool, premiumsAccount, referenceOracle, assetOracle);
-
-    expect(await inverseRm.getCurrentPrice()).to.equal(_W("2.5"));
-  });
-
-  it("Should calculate exchange rate between different assets (Ray vs 9 decimals)", async () => {
-    const { pool, premiumsAccount } = await helpers.loadFixture(deployPoolFixture);
-
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 27, 9);
-
-    const _A27 = _R;
-    const _A9 = amountFunction(9);
-
-    await addRound(assetOracle, _A27("0.001"));
-    await addRound(referenceOracle, _A9(0.08));
-
-    expect(await rm.getCurrentPrice()).to.equal(_A9("0.0125"));
-
-    const inverseRm = await addPriceRiskModule(pool, premiumsAccount, referenceOracle, assetOracle);
-
-    expect(await inverseRm.getCurrentPrice()).to.equal(_A27("80"));
+    [premium, pricing] = await rm.pricePolicy(_E("0.0006675"), true, _A(1000), start + HOUR * 2);
+    expect(pricing.lossProb).to.equal(_W("0.5"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), pricing.lossProb, start + HOUR * 2));
   });
 
   it("Should not allow policy creation/triggering below min duration", async () => {
     const { pool, premiumsAccount, accessManager, currency } = await helpers.loadFixture(deployPoolFixture);
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
     // Setup pricing
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
     const priceSlots = await rm.PRICE_SLOTS();
     const cdf = new Array(priceSlots);
-    for (let i = 0; i < priceSlots; i++) cdf[i] = _W(i / 100);
-    cdf[priceSlots - 1] = _W("0.5");
+    for (let i = 0; i < priceSlots; i++) cdf[i] = [_W(i / 100), 0, _W(1)];
+    cdf[priceSlots - 1] = [_W("0.5"), 0, _W(1)];
     await rm.connect(owner).setCDF(2, cdf);
     await rm.connect(owner).setCDF(3, cdf);
 
@@ -355,11 +282,9 @@ describe("Test PriceRiskModule contract", function () {
     await rm.setMinDuration(HOUR * 2);
 
     // Setup oracle
-    await addRound(assetOracle, _E("0.0005")); // 1 ETH = 2000 WMATIC
-    await addRound(referenceOracle, _E("0.000333333")); // 1 ETH = 3000 USDC
-    // => 1 WMATIC = 1.5 USDC
+    await oracle.setPrice(_E("1.5"));
 
-    const start = await blockchainNow(owner);
+    const start = await helpers.time.latest();
     const triggerPrice = _E("1.1");
 
     // Duration = 2 hours is rejected
@@ -369,8 +294,8 @@ describe("Test PriceRiskModule contract", function () {
 
     // Duration = 3 hours is accepted
     const expiration = start + HOUR * 3;
-    const [premium, lossProb] = await rm.pricePolicy(triggerPrice, true, _A(1000), expiration);
-    expect(lossProb).to.be.equal(_W("0.27"));
+    const [premium, pricing] = await rm.pricePolicy(triggerPrice, true, _A(1000), expiration);
+    expect(pricing.lossProb).to.be.equal(_W("0.27"));
 
     await currency.connect(cust).approve(pool.address, premium);
 
@@ -381,327 +306,158 @@ describe("Test PriceRiskModule contract", function () {
 
     // The policy cannot be triggered within the next two hours, even if triggerPrice is reached
     await helpers.time.increase(HOUR);
-    await addRound(assetOracle, _E("0.00035")); // 1 ETH = 2857 WMATIC
-    await addRound(referenceOracle, _E("0.000333333")); // 1 ETH = 3000 USDC - Just refreshing price
+    await oracle.setPrice(_E("1.05"));
     await expect(rm.triggerPolicy(policyId)).to.be.revertedWith("Too soon to trigger the policy");
 
     // The policy can be triggered after the min duration
     await helpers.time.increase(HOUR);
-    await addRound(assetOracle, _E("0.00035")); // 1 ETH = 2857 WMATIC - Just refreshing price
-    await addRound(referenceOracle, _E("0.000333333")); // 1 ETH = 3000 USDC - Just refreshing price
     await expect(() => rm.triggerPolicy(policyId)).to.changeTokenBalance(currency, cust, _A(1000));
   });
 
   it("Should calculate policy premium and loss probability (1% slots)", async () => {
     const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    await addRound(assetOracle, _E("0.0005")); // 1 ETH = 2000 WMATIC
-    await addRound(referenceOracle, _E("0.000333333")); // 1 ETH = 3000 USDC
-    // Therefore 1 WMATIC = 1.5 USDC
+    await oracle.setPrice(_E("1.5"));
 
-    const start = await blockchainNow(owner);
+    const start = await helpers.time.latest();
 
-    const [price0, lossProb0] = await rm.pricePolicy(_E("1.1"), true, _A(1000), start + HOUR * 2);
+    const [price0, princing0] = await rm.pricePolicy(_E("1.1"), true, _A(1000), start + HOUR * 2);
     expect(price0).to.equal(0);
-    expect(lossProb0).to.equal(0);
+    expect(princing0.lossProb).to.equal(0);
 
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
 
     const priceSlots = await rm.PRICE_SLOTS();
 
     const cdf = new Array(priceSlots);
-    for (let i = 0; i < priceSlots; i++) cdf[i] = _W(i / 100);
-    cdf[priceSlots - 1] = _W("0.5");
+    for (let i = 0; i < priceSlots; i++) cdf[i] = [_W(i / 100), 0, _W(1)];
+    cdf[priceSlots - 1] = [_W("0.5"), 0, _W(1)];
     await rm.connect(owner).setCDF(2, cdf);
 
     // With a variation of 0.4% ($1.5 -> 1.494) we have the probability of the first slot
-    let [premium, lossProb] = await rm.pricePolicy(_E("1.494"), true, _A(1000), start + HOUR * 2);
-    expect(lossProb).to.equal(_W(0));
+    let [premium, pricing] = await rm.pricePolicy(_E("1.494"), true, _A(1000), start + HOUR * 2);
+    expect(pricing.lossProb).to.equal(_W(0));
     expect(premium).to.equal(_W(0));
 
     // With a variation of 12.3% ($1.5 -> $1.3155) we have the probability of the 12th slot
-    [premium, lossProb] = await rm.pricePolicy(_E("1.3155"), true, _A(1000), start + HOUR * 2);
-    expect(lossProb).to.equal(_W("0.12"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, start + HOUR * 2));
+    [premium, pricing] = await rm.pricePolicy(_E("1.3155"), true, _A(1000), start + HOUR * 2);
+    expect(pricing.lossProb).to.equal(_W("0.12"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), pricing.lossProb, start + HOUR * 2));
 
     // With a variation of 26.6% ($1.5 -> $1.1) we have the probability of the 27th slot
-    [premium, lossProb] = await rm.pricePolicy(_E("1.1"), true, _A(1000), start + HOUR * 2);
-    expect(lossProb).to.equal(_W("0.27"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, start + HOUR * 2));
+    [premium, pricing] = await rm.pricePolicy(_E("1.1"), true, _A(1000), start + HOUR * 2);
+    expect(pricing.lossProb).to.equal(_W("0.27"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), pricing.lossProb, start + HOUR * 2));
 
     // With a variation of 46.6% ($1.5 -> $0.8) we have the probability of the last slot
-    [premium, lossProb] = await rm.pricePolicy(_E("0.8"), true, _A(1000), start + HOUR * 2);
-    expect(lossProb).to.equal(_W("0.5"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, start + HOUR * 2));
+    [premium, pricing] = await rm.pricePolicy(_E("0.8"), true, _A(1000), start + HOUR * 2);
+    expect(pricing.lossProb).to.equal(_W("0.5"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), pricing.lossProb, start + HOUR * 2));
   });
 
   it("Should calculate policy premium and loss probability (13% slots)", async () => {
     const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(
-      pool,
-      premiumsAccount,
-      18,
-      18,
-      HOUR,
-      _W("0.13")
-    );
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount, undefined, _W("0.13"));
 
-    await addRound(assetOracle, _E("1.481481")); // 1 ETH = 0.675 WMATIC
-    await addRound(referenceOracle, _E("0.000740")); // 1 ETH = 1350 USDC
-    // Therefore 1 WMATIC = 2000 USDC
+    await oracle.setPrice(_E("2000"));
 
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
 
     const priceSlots = await rm.PRICE_SLOTS();
-    const cdf = _makeArray(priceSlots, 0);
-    cdf[0] = _W("0.5");
-    cdf[2] = _W("0.7");
-    cdf[8] = _W("0.001");
+    const cdf = Array(priceSlots).fill([0, 0, 0]);
+    cdf[0] = [_W("0.5"), 0, _W(1)];
+    cdf[2] = [_W("0.7"), 0, _W(1)];
+    cdf[8] = [_W("0.001"), 0, _W(1)];
     await rm.connect(owner).setCDF(2, cdf);
 
-    const start = await blockchainNow(owner);
+    const start = await helpers.time.latest();
     const expiration = start + HOUR * 2;
 
     // With a variation of 0.4% ($2000 -> $1992) we have the probability of the first slot
-    let [premium, lossProb] = await rm.pricePolicy(_E("1992"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.5"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
+    let [premium, pricing] = await rm.pricePolicy(_E("1992"), true, _A(1000), expiration);
+    expect(pricing.lossProb).to.equal(_W("0.5"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), pricing.lossProb, expiration));
 
     // With a variation of 30% we have the probability of the 2nd slot
-    [premium, lossProb] = await rm.pricePolicy(_E("1400"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.7"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
+    [premium, pricing] = await rm.pricePolicy(_E("1400"), true, _A(1000), expiration);
+    expect(pricing.lossProb).to.equal(_W("0.7"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), pricing.lossProb, expiration));
 
     // With a variation of 100% we have the probability of the 8th slot
-    [premium, lossProb] = await rm.pricePolicy(_E("0"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.001"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
+    [premium, pricing] = await rm.pricePolicy(_E("0"), true, _A(1000), expiration);
+    expect(pricing.lossProb).to.equal(_W("0.001"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), pricing.lossProb, expiration));
   });
 
   it("Should calculate policy premium and loss probability (5% slots, shorted asset)", async () => {
     const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(
-      pool,
-      premiumsAccount,
-      18,
-      18,
-      HOUR,
-      _W("0.05")
-    );
-
-    await addRound(assetOracle, _E("1.481481")); // 1 ETH = 0.675 WMATIC
-    await addRound(referenceOracle, _E("0.0005")); // 1 ETH = 2000 USDC
-    // Therefore 1 WMATIC = 2963.682 USDC
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount, undefined, _W("0.05"));
+    await oracle.setPrice(_E("2963.682"));
 
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
 
     const priceSlots = await rm.PRICE_SLOTS();
-    const cdf = _makeArray(priceSlots, 0);
-    cdf[0] = _W("0.5");
-    cdf[5] = _W("0.03");
-    cdf[20] = _W("0.0001");
-    cdf[priceSlots - 1] = _W("0.000005");
+    const cdf = Array(priceSlots).fill([0, 0, 0]);
+    cdf[0] = [_W("0.5"), 0, _W(1)];
+    cdf[5] = [_W("0.03"), 0, _W(1)];
+    cdf[20] = [_W("0.0001"), 0, _W(1)];
+    cdf[priceSlots - 1] = [_W("0.000005"), 0, _W(1)];
     await rm.connect(owner).setCDF(-3, cdf);
 
-    const start = await blockchainNow(owner);
+    const start = await helpers.time.latest();
     const expiration = start + HOUR * 3;
 
     // With a variation of 0.000444% we have the probability of the first slot
-    let [premium, lossProb] = await rm.pricePolicy(_E("2965"), false, _A(2000), expiration);
-    expect(lossProb).to.equal(_W("0.5"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(2000), lossProb, expiration));
+    let [premium, pricing] = await rm.pricePolicy(_E("2965"), false, _A(2000), expiration);
+    expect(pricing.lossProb).to.equal(_W("0.5"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(2000), pricing.lossProb, expiration));
 
     // With a variation of 27% we have the probability of the 5th slot
-    [premium, lossProb] = await rm.pricePolicy(_E("3763"), false, _A(2000), expiration);
-    expect(lossProb).to.equal(_W("0.03"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(2000), lossProb, expiration));
+    [premium, pricing] = await rm.pricePolicy(_E("3763"), false, _A(2000), expiration);
+    expect(pricing.lossProb).to.equal(_W("0.03"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(2000), pricing.lossProb, expiration));
 
     // With a variation of 100% we have the probability of the 20th slot
-    [premium, lossProb] = await rm.pricePolicy(_E("5928"), false, _A(2000), expiration);
-    expect(lossProb).to.equal(_W("0.0001"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(2000), lossProb, expiration));
+    [premium, pricing] = await rm.pricePolicy(_E("5928"), false, _A(2000), expiration);
+    expect(pricing.lossProb).to.equal(_W("0.0001"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(2000), pricing.lossProb, expiration));
 
     // With a variation of 150% we have the probability of the last slot
-    [premium, lossProb] = await rm.pricePolicy(_E("7410"), false, _A(2000), expiration);
-    expect(lossProb).to.equal(_W("0.000005"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(2000), lossProb, expiration));
-  });
-
-  it("Should calculate policy premium and loss probability (1% slots, Wad vs 6 decimals)", async () => {
-    const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
-
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 6);
-
-    await addRound(assetOracle, _E("0.0005")); // 1 USD = 2000 WMATIC
-    await addRound(referenceOracle, _A("0.000333")); // 1 USD = 3000 RTK
-    // Therefore 1 WMATIC = 1.5 RTK
-
-    const start = await blockchainNow(owner);
-    const expiration = start + HOUR * 2;
-
-    const [price0, lossProb0] = await rm.pricePolicy(_A("1.1"), true, _A(1000), expiration);
-    expect(price0).to.equal(0);
-    expect(lossProb0).to.equal(0);
-
-    await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
-
-    const priceSlots = await rm.PRICE_SLOTS();
-
-    const cdf = new Array(priceSlots);
-    for (let i = 0; i < priceSlots; i++) cdf[i] = _W(i / 100);
-    cdf[priceSlots - 1] = _W("0.5");
-    await rm.connect(owner).setCDF(2, cdf);
-
-    // With a variation of 0.4% ($1.5 -> 1.494) we have the probability of the first slot
-    let [premium, lossProb] = await rm.pricePolicy(_A("1.494"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W(0));
-    expect(premium).to.equal(_W(0));
-
-    // With a variation of 12.3% ($1.5 -> $1.3155) we have the probability of the 12th slot
-    [premium, lossProb] = await rm.pricePolicy(_A("1.3155"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.12"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
-
-    // With a variation of 26.6% ($1.5 -> $1.1) we have the probability of the 27th slot
-    [premium, lossProb] = await rm.pricePolicy(_A("1.1"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.27"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
-
-    // With a variation of 46.6% ($1.5 -> $0.8) we have the probability of the last slot
-    [premium, lossProb] = await rm.pricePolicy(_A("0.8"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.5"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
-  });
-
-  it("Should calculate policy premium and loss probability (1% slots, Ray vs 9 decimals)", async () => {
-    const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
-
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 27, 9);
-
-    const _A27 = _R;
-    const _A9 = amountFunction(9);
-
-    await addRound(assetOracle, _A27("0.0005")); // 1 Ray = 2000 WMATIC
-    await addRound(referenceOracle, _A9("0.000333")); // 1 Ray = 3000 RTK
-    // Therefore 1 WMATIC = 1.5 RTK
-
-    const start = await blockchainNow(owner);
-    const expiration = start + HOUR * 2;
-
-    const [price0, lossProb0] = await rm.pricePolicy(_A9("1.1"), true, _A(1000), expiration);
-    expect(price0).to.equal(0);
-    expect(lossProb0).to.equal(0);
-
-    await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
-
-    const priceSlots = await rm.PRICE_SLOTS();
-
-    const cdf = new Array(priceSlots);
-    for (let i = 0; i < priceSlots; i++) cdf[i] = _W(i / 100);
-    cdf[priceSlots - 1] = _W("0.5");
-    await rm.connect(owner).setCDF(2, cdf);
-
-    // With a variation of 0.4% ($1.5 -> 1.494) we have the probability of the first slot
-    let [premium, lossProb] = await rm.pricePolicy(_A9("1.494"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W(0));
-    expect(premium).to.equal(_W(0));
-
-    // With a variation of 12.3% ($1.5 -> $1.3155) we have the probability of the 12th slot
-    [premium, lossProb] = await rm.pricePolicy(_A9("1.3155"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.12"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
-
-    // With a variation of 26.6% ($1.5 -> $1.1) we have the probability of the 27th slot
-    [premium, lossProb] = await rm.pricePolicy(_A9("1.1"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.27"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
-
-    // With a variation of 46.6% ($1.5 -> $0.8) we have the probability of the last slot
-    [premium, lossProb] = await rm.pricePolicy(_A9("0.8"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.5"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
-  });
-
-  it("Should calculate policy premium and loss probability (1% slots, Ray vs 6 decimals)", async () => {
-    const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
-
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 27, 6);
-
-    const _A27 = _R;
-
-    await addRound(assetOracle, _A27("0.0005")); // 1 Ray = 2000 WMATIC
-    await addRound(referenceOracle, _A("0.000333")); // 1 Ray = 3000 RTK
-    // Therefore 1 WMATIC = 1.5 RTK
-
-    const start = await blockchainNow(owner);
-    const expiration = start + HOUR * 2;
-
-    const [price0, lossProb0] = await rm.pricePolicy(_A("1.1"), true, _A(1000), expiration);
-    expect(price0).to.equal(0);
-    expect(lossProb0).to.equal(0);
-
-    await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
-
-    const priceSlots = await rm.PRICE_SLOTS();
-
-    const cdf = new Array(priceSlots);
-    for (let i = 0; i < priceSlots; i++) cdf[i] = _W(i / 100);
-    cdf[priceSlots - 1] = _W("0.5");
-    await rm.connect(owner).setCDF(2, cdf);
-
-    // With a variation of 0.4% ($1.5 -> 1.494) we have the probability of the first slot
-    let [premium, lossProb] = await rm.pricePolicy(_A("1.494"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W(0));
-    expect(premium).to.equal(_W(0));
-
-    // With a variation of 12.3% ($1.5 -> $1.3155) we have the probability of the 12th slot
-    [premium, lossProb] = await rm.pricePolicy(_A("1.3155"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.12"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
-
-    // With a variation of 26.6% ($1.5 -> $1.1) we have the probability of the 27th slot
-    [premium, lossProb] = await rm.pricePolicy(_A("1.1"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.27"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
-
-    // With a variation of 46.6% ($1.5 -> $0.8) we have the probability of the last slot
-    [premium, lossProb] = await rm.pricePolicy(_A("0.8"), true, _A(1000), expiration);
-    expect(lossProb).to.equal(_W("0.5"));
-    expect(premium).to.equal(await rm.getMinimumPremium(_A(1000), lossProb, expiration));
+    [premium, pricing] = await rm.pricePolicy(_E("7410"), false, _A(2000), expiration);
+    expect(pricing.lossProb).to.equal(_W("0.000005"));
+    expect(premium).to.equal(await rm.getMinimumPremium(_A(2000), pricing.lossProb, expiration));
   });
 
   it("Should trigger the policy only if threshold met", async () => {
     const { pool, premiumsAccount, accessManager, currency } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    await addRound(assetOracle, _E("0.00056")); // 1 ETH = 1785.71... WMATIC
-    await addRound(referenceOracle, _E("0.0004")); // 1 ETH = 2500 USDC
-    // Therefore 1 WMATIC = 1.4 USDC
+    await oracle.setPrice(_E("1.4"));
 
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
 
     // Set price
     const priceSlots = await rm.PRICE_SLOTS();
-    const cdf = _makeArray(priceSlots, 0);
-    cdf[20] = _W("0.03");
-    cdf[21] = _W("0.05");
-    cdf[priceSlots - 1] = _W("0.1");
+    const cdf = Array(priceSlots).fill([0, 0, 0]);
+    cdf[20] = [_W("0.03"), 0, _W(1)];
+    cdf[21] = [_W("0.05"), 0, _W(1)];
+    cdf[priceSlots - 1] = [_W("0.1"), 0, _W(1)];
     await rm.connect(owner).setCDF(2, cdf);
 
-    const start = await blockchainNow(owner);
+    const start = await helpers.time.latest();
     const expiration = start + HOUR * 2;
 
     await expect(rm.connect(cust).newPolicy(_E("1.2"), true, _A(1000), expiration, cust.address)).to.be.revertedWith(
       "Either duration or percentage jump not supported"
     );
 
-    const [premium, lossProb] = await rm.pricePolicy(_E("1.1"), true, _A(1000), expiration);
-    expect(lossProb).to.be.equal(_W("0.05"));
+    const [premium, pricing] = await rm.pricePolicy(_E("1.1"), true, _A(1000), expiration);
+    expect(pricing.lossProb).to.be.equal(_W("0.05"));
 
     await currency.connect(cust).approve(pool.address, premium);
 
@@ -724,38 +480,34 @@ describe("Test PriceRiskModule contract", function () {
 
     // Move time forward and refresh oracle with the same prices
     await helpers.time.increase(HOUR);
-    await addRound(assetOracle, _E("0.00056"));
-    await addRound(referenceOracle, _E("0.0004"));
 
     await expect(rm.triggerPolicy(policyId)).to.be.revertedWith("Condition not met CurrentPrice > triggerPrice");
 
     // Change price of asset to 1.1
-    await addRound(assetOracle, _E("0.00044")); // 1 ETH = 2272.7... WMATIC
+    await oracle.setPrice(_E("1.1"));
     await expect(() => rm.triggerPolicy(policyId)).to.changeTokenBalance(currency, cust, _A(1000));
   });
 
   it("Should trigger the policy only if threshold met - Shorted asset", async () => {
     const { pool, premiumsAccount, accessManager, currency } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm, assetOracle, referenceOracle } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm, oracle } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
-    await addRound(assetOracle, _E("0.00056")); // 1 ETH = 1785.71... WMATIC
-    await addRound(referenceOracle, _E("0.0004")); // 1 ETH = 2500 USDC
-    // Therefore 1 WMATIC = 1.4 USDC
+    await oracle.setPrice(_E("1.4"));
 
     // Set price
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
     const priceSlots = await rm.PRICE_SLOTS();
-    const cdf = _makeArray(priceSlots, 0);
-    cdf[20] = _W("0.02");
-    cdf[21] = _W("0.04");
-    cdf[priceSlots - 1] = _W("0.1");
+    const cdf = Array(priceSlots).fill([0, 0, 0]);
+    cdf[20] = [_W("0.02"), 0, _W(1)];
+    cdf[21] = [_W("0.04"), 0, _W(1)];
+    cdf[priceSlots - 1] = [_W("0.1"), 0, _W(1)];
     await rm.connect(owner).setCDF(-2, cdf);
 
-    const start = await blockchainNow(owner);
+    const start = await helpers.time.latest();
 
-    const [premium, lossProb] = await rm.pricePolicy(_E("1.7"), false, _A(1000), start + HOUR * 2);
-    expect(lossProb).to.be.equal(_W("0.04"));
+    const [premium, princing] = await rm.pricePolicy(_E("1.7"), false, _A(1000), start + HOUR * 2);
+    expect(princing.lossProb).to.be.equal(_W("0.04"));
     await currency.connect(cust).approve(pool.address, premium);
 
     let tx = await rm.connect(cust).newPolicy(_E("1.7"), false, _A(1000), start + HOUR * 2, cust.address);
@@ -775,20 +527,18 @@ describe("Test PriceRiskModule contract", function () {
 
     // Move time forward and refresh oracle with the same prices
     await helpers.time.increase(HOUR);
-    await addRound(assetOracle, _E("0.00056"));
-    await addRound(referenceOracle, _E("0.0004"));
 
     await expect(rm.triggerPolicy(policyId)).to.be.revertedWith("Condition not met CurrentPrice < triggerPrice");
 
     // Change price of WMATIC to 1.75
-    await addRound(assetOracle, _E("0.0007"));
+    await oracle.setPrice(_E("1.75"));
     await expect(() => rm.triggerPolicy(policyId)).to.changeTokenBalance(currency, cust, _A(1000));
   });
 
   it("Should not allow operations when paused", async () => {
     const { pool, premiumsAccount, accessManager } = await helpers.loadFixture(deployPoolFixture);
 
-    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount, 18, 18);
+    const { rm } = await addRiskModuleWithOracles(pool, premiumsAccount);
 
     await expect(rm.pause()).to.be.revertedWith(accessControlMessage(owner.address, rm.address, "GUARDIAN_ROLE"));
     expect(await rm.paused()).to.equal(false);
@@ -799,62 +549,18 @@ describe("Test PriceRiskModule contract", function () {
 
     await grantComponentRole(hre, accessManager, rm, "PRICER_ROLE", owner.address);
     const priceSlots = await rm.PRICE_SLOTS();
-    const cdf = _makeArray(priceSlots, 0);
+    const cdf = Array(priceSlots).fill([0, 0, 0]);
     await expect(rm.setCDF(1, cdf)).to.be.revertedWith("Pausable: paused");
 
     await expect(
-      rm.newPolicy(_E("1.1"), true, _A(1000), (await blockchainNow(owner)) + HOUR, cust.address)
+      rm.newPolicy(_E("1.1"), true, _A(1000), (await helpers.time.latest()) + HOUR, cust.address)
     ).to.be.revertedWith("Pausable: paused");
     await expect(rm.triggerPolicy(1)).to.be.revertedWith("Pausable: paused");
 
     await grantComponentRole(hre, accessManager, rm, "ORACLE_ADMIN_ROLE", owner.address);
-    await expect(rm.setOracleTolerance(1800)).to.be.revertedWith("Pausable: paused");
+    await expect(rm.setOracle(ethers.constants.AddressZero)).to.be.revertedWith("Pausable: paused");
 
     await expect(rm.setMinDuration(1800)).to.be.revertedWith("Pausable: paused");
-  });
-
-  forkIt("Should work with real chainlink oracles (forking at https://polygonscan.com/block/34906609)", async () => {
-    if (process.env.ALCHEMY_URL === undefined) throw new Error("Define envvar ALCHEMY_URL for this test");
-    await hre.network.provider.request({
-      method: "hardhat_reset",
-      params: [
-        {
-          forking: {
-            jsonRpcUrl: process.env.ALCHEMY_URL,
-            blockNumber: 34906609, // polygon mainnet
-          },
-        },
-      ],
-    });
-
-    const _U = amountFunction(8);
-
-    const { pool, premiumsAccount } = await deployPoolFixture(); // Can't use loadFixture on fork
-
-    const BNB_ORACLE_ADDRESS = "0x82a6c4AF830caa6c97bb504425f6A66165C2c26e";
-    const USDC_ORACLE_ADDRESS = "0xfE4A8cc5b5B2366C1B58Bea3858e81843581b2F7";
-
-    const assetOracle = await hre.ethers.getContractAt("AggregatorV3Interface", BNB_ORACLE_ADDRESS);
-    const referenceOracle = await hre.ethers.getContractAt("AggregatorV3Interface", USDC_ORACLE_ADDRESS);
-
-    // Sanity check: are we in the right chain with the right block?
-    const [, assetPrice] = await assetOracle.latestRoundData();
-    expect(assetPrice).to.equal(_U("293.18"));
-    const [, referencePrice] = await referenceOracle.latestRoundData();
-    expect(referencePrice).to.equal(_U("1.00002339"));
-
-    // Contract setup
-    const PriceRiskModule = await hre.ethers.getContractFactory("PriceRiskModule");
-    const rm = await addRiskModule(pool, premiumsAccount, PriceRiskModule, {
-      extraConstructorArgs: [assetOracle.address, referenceOracle.address, _W("0.01")],
-      extraArgs: [HOUR],
-    });
-
-    expect(await rm.getCurrentPrice()).to.equal(_U("293.17314268"));
-
-    const inverseRm = await addPriceRiskModule(pool, premiumsAccount, referenceOracle, assetOracle);
-
-    expect(await inverseRm.getCurrentPrice()).to.equal(_U("0.00341095"));
   });
 
   async function deployPoolFixture() {
@@ -890,60 +596,31 @@ describe("Test PriceRiskModule contract", function () {
       wmatic,
     };
   }
-
-  async function addRound(oracle, price, startedAt, updatedAt, answeredInRound) {
-    const now = await blockchainNow(owner);
-    return oracle._addRound(price, startedAt || now, updatedAt || now, answeredInRound || 0);
-  }
 });
 
 async function addRiskModuleWithOracles(
   pool,
   premiumsAccount,
-  assetDecimals,
-  referenceDecimals,
-  oracleTolerance = HOUR,
-  slotSize = _W("0.01")
+  oracle = undefined,
+  slotSize = _W("0.01"),
+  price = undefined
 ) {
-  const PriceOracle = await hre.ethers.getContractFactory("AggregatorV3Mock");
-
-  const assetOracle = await PriceOracle.deploy(assetDecimals);
-  assetOracle._P = amountFunction(assetDecimals);
-
-  let referenceOracle;
-  if (referenceDecimals !== undefined) {
-    referenceOracle = await PriceOracle.deploy(referenceDecimals);
-    referenceOracle._P = amountFunction(referenceDecimals);
-  } else {
-    referenceOracle = { address: hre.ethers.constants.AddressZero };
+  if (oracle === undefined) {
+    const PriceOracleMock = await hre.ethers.getContractFactory("PriceOracleMock");
+    oracle = await PriceOracleMock.deploy(price || _W(0));
   }
 
-  const rm = await addPriceRiskModule(pool, premiumsAccount, assetOracle, referenceOracle, oracleTolerance, slotSize);
+  const rm = await addPriceRiskModule(pool, premiumsAccount, oracle, slotSize);
 
-  return { PriceOracle, assetOracle, referenceOracle, rm };
+  return { oracle, rm };
 }
 
-async function addPriceRiskModule(
-  pool,
-  premiumsAccount,
-  assetOracle,
-  referenceOracle,
-  oracleTolerance = HOUR,
-  slotSize = _W("0.01")
-) {
+async function addPriceRiskModule(pool, premiumsAccount, oracle, slotSize = _W("0.01")) {
   const PriceRiskModule = await hre.ethers.getContractFactory("PriceRiskModule");
   const rm = await addRiskModule(pool, premiumsAccount, PriceRiskModule, {
-    extraConstructorArgs: [assetOracle.address, referenceOracle.address, slotSize],
-    extraArgs: [oracleTolerance],
+    extraConstructorArgs: [slotSize],
+    extraArgs: [oracle.address],
   });
 
   return rm;
-}
-
-function _makeArray(n, initialValue) {
-  const ret = new Array(n);
-  for (let i = 0; i < n; i++) {
-    ret[i] = initialValue;
-  }
-  return ret;
 }


### PR DESCRIPTION
Now the pricing for each policy depending on the price drop includes not only the lossProb but also the junior and total collateralization ratios.

Also, I extracted all the oracle related logic to an external contract (IPriceOracle).
This contract has a simple interface that just returns the currentPrice in wad.

The chainlink related code is now moved to ChainlinkPriceOracle that implements the IPriceOracle interface using two underlying chainlink oracles (asset and reference).