### PR TITLE
getPolicyData endpoint to access policy parameters

### DIFF
--- a/contracts/ChainlinkPriceOracle.sol
+++ b/contracts/ChainlinkPriceOracle.sol
@@ -29,7 +29,7 @@ contract ChainlinkPriceOracle is IPriceOracle {
   /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
   AggregatorV3Interface internal immutable _referenceOracle;
   /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-  uint256 internal _oracleTolerance;
+  uint256 internal immutable _oracleTolerance;
 
   /**
    * @dev Constructs the PriceRiskModule.

--- a/contracts/PriceRiskModule.sol
+++ b/contracts/PriceRiskModule.sol
@@ -195,6 +195,10 @@ contract PriceRiskModule is RiskModule, IPriceRiskModule {
     );
 
     _policyPool.resolvePolicy(policy.ensuroPolicy, policy.ensuroPolicy.payout);
+    // Be aware that `_policies` is not deleted when a policy is resolved, so getPolicyData will keep returning
+    // the policy information, despite the policy is no longer claimable. To check if the policy is active, you should
+    // call PolicyPool.getPolicyHash(policyId) and if the output is bytes32(0), that means the policy is no longer
+    // active.
   }
 
   /**
@@ -345,6 +349,10 @@ contract PriceRiskModule is RiskModule, IPriceRiskModule {
     p.jrCollRatio = uint256(pricing.jrCollRatio);
     p.collRatio = uint256(pricing.collRatio);
     return _getMinimumPremium(payout, pricing.lossProb, expiration, p);
+  }
+
+  function getPolicyData(uint256 policyId) external view returns (PolicyData memory) {
+    return _policies[policyId];
   }
 
   /**


### PR DESCRIPTION
New endpoint that allows to query trigger price and other values.

Also, changed to immutable one attribute of ChainlinkPriceOracle since it wasn't modifiable anyway. To change the tolerance you have to change the oracle.