### PR TITLE
AAVE Buy Eth Payout Automation with Gelato

### DIFF
--- a/contracts/payout-automations/AAVEBuyEthPayoutAutomation.sol
+++ b/contracts/payout-automations/AAVEBuyEthPayoutAutomation.sol
@@ -44,6 +44,9 @@ contract AAVEBuyEthPayoutAutomation is PayoutAutomationBaseGelato {
   }
 
   function _handlePayout(address receiver, uint256 amount) internal override {
+    // WARNING: in this contract, different to other payout automations, the amount received is in ETH,
+    // since all the USD were already exchanged in the _payTxFee function. This is to avoid doing the exchange twice.
+    // "Practicality beats purity"
     address asset = address(weth);
     if (amount != 0) {
       _aave.supply(asset, amount, receiver, 0);
@@ -86,6 +89,8 @@ contract AAVEBuyEthPayoutAutomation is PayoutAutomationBaseGelato {
     weth.withdraw(fee);
     _transfer(fee, feeToken);
 
+    // WARNING: this returns the remaining amount in ETH, this is different from other payout automations
+    // The reason is we already exchanged all the USD for ETH. "Practicality beats purity"
     return receivedEth - fee;
   }
 

--- a/contracts/payout-automations/AAVEBuyEthPayoutAutomation.sol
+++ b/contracts/payout-automations/AAVEBuyEthPayoutAutomation.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {PayoutAutomationBaseGelato} from "./PayoutAutomationBaseGelato.sol";
+import {WadRayMath} from "@ensuro/core/contracts/dependencies/WadRayMath.sol";
+import {IPolicyPool} from "@ensuro/core/contracts/interfaces/IPolicyPool.sol";
+import {IWETH9} from "../dependencies/uniswap-v3/IWETH9.sol";
+import {IPool} from "../dependencies/aave-v3/IPool.sol";
+import {IPriceOracle} from "../interfaces/IPriceOracle.sol";
+import {ISwapRouter} from "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+
+contract AAVEBuyEthPayoutAutomation is PayoutAutomationBaseGelato {
+  using WadRayMath for uint256;
+
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+  IPool internal immutable _aave;
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  // solhint-disable-next-line no-empty-blocks
+  constructor(
+    IPolicyPool policyPool_,
+    address automate_,
+    IWETH9 weth_,
+    IPool aave_
+  ) PayoutAutomationBaseGelato(policyPool_, automate_, weth_) {
+    require(
+      address(aave_) != address(0),
+      "AAVEBuyEthPayoutAutomation: you must specify AAVE's Pool address"
+    );
+    _aave = aave_;
+  }
+
+  function initialize(
+    string memory name_,
+    string memory symbol_,
+    address admin,
+    IPriceOracle oracle_,
+    ISwapRouter swapRouter_,
+    uint24 feeTier_
+  ) public virtual initializer {
+    __PayoutAutomationBaseGelato_init(name_, symbol_, admin, oracle_, swapRouter_, feeTier_);
+    // Infinite approval to AAVE to avoid approving every time
+    weth.approve(address(_aave), type(uint256).max);
+  }
+
+  function _handlePayout(address receiver, uint256 amount) internal override {
+    address asset = address(weth);
+    if (amount != 0) {
+      _aave.supply(asset, amount, receiver, 0);
+    }
+  }
+
+  /**
+   * @dev Exchange ALL the payout for ETH, pay gelato for the transaction fee and return the remaining amount
+   * @param amount The payout amount that was received
+   * @return The remaining amount in ETH after paying the transaction fee
+   */
+  function _payTxFee(uint256 amount) internal override returns (uint256) {
+    (uint256 fee, address feeToken) = _getFeeDetails();
+    require(feeToken == ETH, "Unsupported feeToken for gelato payment");
+
+    uint256 ethMin = (amount * _wadToCurrencyFactor).wadDiv(_oracle.getCurrentPrice()).wadMul(
+      WAD - _priceTolerance
+    );
+
+    ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
+      tokenIn: address(_policyPool.currency()),
+      tokenOut: address(weth),
+      fee: _swapParams.feeTier,
+      recipient: address(this),
+      deadline: block.timestamp,
+      amountIn: amount,
+      amountOutMinimum: ethMin,
+      sqrtPriceLimitX96: 0 // Since we're limiting the transfer amount, we don't need to worry about the price impact of the transaction
+    });
+
+    uint256 receivedEth = _swapParams.swapRouter.exactInputSingle(params);
+
+    // Sanity check
+    require(
+      (receivedEth >= ethMin) && (receivedEth >= fee),
+      "AAVEBuyEthPayoutAutomation: the payout is not enough to cover the tx fees"
+    );
+
+    // Convert the WMATIC to MATIC for fee payment
+    weth.withdraw(fee);
+    _transfer(fee, feeToken);
+
+    return receivedEth - fee;
+  }
+
+  /**
+   * @dev This empty reserved space is put in place to allow future versions to add new
+   * variables without shifting down storage in the inheritance chain.
+   * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+   */
+  uint256[50] private __gap;
+}

--- a/contracts/payout-automations/AAVERepayPayoutAutomation.sol
+++ b/contracts/payout-automations/AAVERepayPayoutAutomation.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {PayoutAutomationBaseGelato} from "./PayoutAutomationBaseGelato.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {IPolicyPool} from "@ensuro/core/contracts/interfaces/IPolicyPool.sol";
@@ -13,8 +12,6 @@ import {DataTypes} from "../dependencies/aave-v3/DataTypes.sol";
 import {ISwapRouter} from "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 
 contract AAVERepayPayoutAutomation is PayoutAutomationBaseGelato {
-  using SafeERC20 for IERC20Metadata;
-
   /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
   IPool internal immutable _aave;
 
@@ -64,7 +61,7 @@ contract AAVERepayPayoutAutomation is PayoutAutomationBaseGelato {
       }
     }
     if (amount != 0) {
-      _aave.deposit(asset, amount, receiver, 0);
+      _aave.supply(asset, amount, receiver, 0);
     }
   }
 

--- a/contracts/payout-automations/PayoutAutomationBaseGelato.sol
+++ b/contracts/payout-automations/PayoutAutomationBaseGelato.sol
@@ -27,29 +27,29 @@ abstract contract PayoutAutomationBaseGelato is AutomateTaskCreator, PayoutAutom
   using WadRayMath for uint256;
   using SafeCast for uint256;
 
-  uint256 private constant WAD = 1e18;
+  uint256 internal constant WAD = 1e18;
 
   /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-  uint256 private immutable _wadToCurrencyFactor;
+  uint256 internal immutable _wadToCurrencyFactor;
   /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-  IWETH9 private immutable weth;
+  IWETH9 internal immutable weth;
 
   struct SwapParams {
     ISwapRouter swapRouter;
     uint24 feeTier;
   }
 
-  SwapParams private _swapParams;
+  SwapParams internal _swapParams;
 
   /**
    * @dev Oracle for the price of gas tokens in the currency of the policy pool
    */
-  IPriceOracle private _oracle;
+  IPriceOracle internal _oracle;
 
   /**
    * @dev Tolerance, in percentage Wad, for price slippage when swapping currency for gas tokens
    */
-  uint256 private _priceTolerance;
+  uint256 internal _priceTolerance;
 
   /**
    * @dev Mapping from policyId to taskIds
@@ -155,7 +155,7 @@ abstract contract PayoutAutomationBaseGelato is AutomateTaskCreator, PayoutAutom
    * @param amount The payout amount that was received
    * @return The remaining amount after paying the transaction fee
    */
-  function _payTxFee(uint256 amount) internal returns (uint256) {
+  function _payTxFee(uint256 amount) internal virtual returns (uint256) {
     (uint256 fee, address feeToken) = _getFeeDetails();
     require(feeToken == ETH, "Unsupported feeToken for gelato payment");
 


### PR DESCRIPTION
New payout automation that exchanges all the USD into ETH, pays the Gelato fee, and supplies the remaining ETH to user's AAVE account.